### PR TITLE
add test displaying problem with changing mutable session values

### DIFF
--- a/pyramid_redis_sessions/tests.py
+++ b/pyramid_redis_sessions/tests.py
@@ -320,6 +320,12 @@ class TestRedisDict(unittest.TestCase):
         for val in self.rdict.iterkeys():
             self.assert_(val in keys)
 
+    def test_mutablevalue_changed(self):
+        self.rdict['a'] = {'1':1, '2':2}
+        tmp = self.rdict['a']
+        tmp['3'] = 4
+        self.assertEqual(self.rdict['a'], {'1':1, '2':2, '3':3})
+
 class TestPyramidRedisSessions(unittest.TestCase):
     def get_client(self, redis=None):
         if redis is None:


### PR DESCRIPTION
This isn't a fix, but just a test that demonstrates a problem with changing mutable values stored in the session.  I suspect fixing it requires a bit of a redesign: instead of serializing each value in the dict separately into redis, the implementation would need to treat a single dict as a serializable entity and store it each time any key or value was added or removed (or when .changed() was called).
