### PR TITLE
Restore redis-py install_requires lower bound.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except IOError:
     README = CHANGES = ''
 
 # set up requires
-install_requires = ['redis<=2.9.1', 'pyramid>=1.3']
+install_requires = ['redis>=2.4.11,<=2.9.1', 'pyramid>=1.3']
 testing_requires = ['nose']
 testing_extras = testing_requires + ['coverage']
 docs_extras = ['sphinx']


### PR DESCRIPTION
As discussed here: https://github.com/ericrasmussen/pyramid_redis_sessions/pull/37#issuecomment-48821643
