### PR TITLE
Feature "consolidated updates"

### DIFF
--- a/pyramid_redis_sessions/__init__.py
+++ b/pyramid_redis_sessions/__init__.py
@@ -341,9 +341,6 @@ def _finished_callback(
     `request` is appended by add_finished_callback
     """
     if session._session_state.please_persist:
-        with session.redis.pipeline() as pipe:
-            pipe.set(session.session_id, session.to_redis())
-            pipe.expire(session.session_id, session.timeout)
-            pipe.execute()
+        session.do_persist()
     elif session._session_state.please_refresh:
-        session.redis.expire(session.session_id, session.timeout)
+        session.do_refresh()

--- a/pyramid_redis_sessions/session.py
+++ b/pyramid_redis_sessions/session.py
@@ -17,6 +17,10 @@ from .util import (
 
 
 class _SessionState(object):
+    # markers for update
+    please_persist = None
+    please_refresh = None
+
     def __init__(self, session_id, managed_dict, created, timeout, new):
         self.session_id = session_id
         self.managed_dict = managed_dict

--- a/pyramid_redis_sessions/tests/__init__.py
+++ b/pyramid_redis_sessions/tests/__init__.py
@@ -3,6 +3,10 @@
 from ..compat import cPickle
 
 
+class DummySessionState(object):
+    please_persist = None
+    please_refresh = None
+
 class DummySession(object):
     def __init__(self, session_id, redis, timeout=300,
                  serialize=cPickle.dumps):
@@ -12,6 +16,7 @@ class DummySession(object):
         self.serialize = serialize
         self.managed_dict = {}
         self.created = float()
+        self._session_state = DummySessionState()
 
     def to_redis(self):
         return self.serialize({

--- a/pyramid_redis_sessions/tests/test_factory.py
+++ b/pyramid_redis_sessions/tests/test_factory.py
@@ -465,6 +465,7 @@ class TestRedisSessionFactory(unittest.TestCase):
         request = self._make_request()
         inst = self._makeOne(request)
         inst.adjust_timeout_for_session(555)
+        inst.do_persist()
         session_id = inst.session_id
         cookieval = self._serialize(session_id)
         request.cookies['session'] = cookieval

--- a/pyramid_redis_sessions/tests/test_session.py
+++ b/pyramid_redis_sessions/tests/test_session.py
@@ -91,6 +91,7 @@ class TestRedisSession(unittest.TestCase):
         inst = self._set_up_session_in_Redis_and_makeOne()
         inst['key'] = 'val'
         del inst['key']
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         self.assertNotIn('key', inst)
         self.assertNotIn('key', session_dict_in_redis)
@@ -98,6 +99,7 @@ class TestRedisSession(unittest.TestCase):
     def test_setitem(self):
         inst = self._set_up_session_in_Redis_and_makeOne()
         inst['key'] = 'val'
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         self.assertIn('key', inst)
         self.assertIn('key', session_dict_in_redis)
@@ -105,12 +107,14 @@ class TestRedisSession(unittest.TestCase):
     def test_getitem(self):
         inst = self._set_up_session_in_Redis_and_makeOne()
         inst['key'] = 'val'
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         self.assertEqual(inst['key'], session_dict_in_redis['key'])
 
     def test_contains(self):
         inst = self._set_up_session_in_Redis_and_makeOne()
         inst['key'] = 'val'
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         self.assert_('key' in inst)
         self.assert_('key' in session_dict_in_redis)
@@ -125,6 +129,7 @@ class TestRedisSession(unittest.TestCase):
         inst['key1'] = ''
         inst['key2'] = ''
         inst_keys = inst.keys()
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         persisted_keys = session_dict_in_redis.keys()
         self.assertEqual(inst_keys, persisted_keys)
@@ -134,6 +139,7 @@ class TestRedisSession(unittest.TestCase):
         inst['a'] = 1
         inst['b'] = 2
         inst_items = inst.items()
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         persisted_items = session_dict_in_redis.items()
         self.assertEqual(inst_items, persisted_items)
@@ -151,6 +157,7 @@ class TestRedisSession(unittest.TestCase):
         inst['key'] = 'val'
         get_from_inst = inst.get('key')
         self.assertEqual(get_from_inst, 'val')
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         get_from_redis = session_dict_in_redis.get('key')
         self.assertEqual(get_from_inst, get_from_redis)
@@ -183,6 +190,7 @@ class TestRedisSession(unittest.TestCase):
         inst.update(to_be_updated)
         self.assertEqual(inst['a'], 'overriden')
         self.assertEqual(inst['b'], 2)
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         self.assertEqual(session_dict_in_redis['a'], 'overriden')
         self.assertEqual(session_dict_in_redis['b'], 2)
@@ -399,6 +407,7 @@ class TestRedisSession(unittest.TestCase):
         tmp = inst['a']
         tmp['3'] = 3
         inst.changed()
+        inst.do_persist()
         session_dict_in_redis = inst.from_redis()['managed_dict']
         self.assertEqual(session_dict_in_redis['a'], {'1':1, '2':2, '3':3})
 
@@ -446,5 +455,6 @@ class TestRedisSession(unittest.TestCase):
         inst = self._set_up_session_in_Redis_and_makeOne(timeout=100)
         adjusted_timeout = 200
         inst.adjust_timeout_for_session(adjusted_timeout)
+        inst.do_persist()
         self.assertEqual(inst.timeout, adjusted_timeout)
         self.assertEqual(inst.from_redis()['timeout'], adjusted_timeout)

--- a/pyramid_redis_sessions/util.py
+++ b/pyramid_redis_sessions/util.py
@@ -139,7 +139,7 @@ def refresh(wrapped):
     """
     def wrapped_refresh(session, *arg, **kw):
         result = wrapped(session, *arg, **kw)
-        session.redis.expire(session.session_id, session.timeout)
+        session._session_state.please_refresh = True
         return result
 
     return wrapped_refresh
@@ -151,10 +151,7 @@ def persist(wrapped):
     """
     def wrapped_persist(session, *arg, **kw):
         result = wrapped(session, *arg, **kw)
-        with session.redis.pipeline() as pipe:
-            pipe.set(session.session_id, session.to_redis())
-            pipe.expire(session.session_id, session.timeout)
-            pipe.execute()
+        session._session_state.please_persist = True
         return result
 
     return wrapped_persist

--- a/pyramid_redis_sessions/util.py
+++ b/pyramid_redis_sessions/util.py
@@ -133,9 +133,13 @@ def _parse_settings(settings):
 
     return options
 
+
 def refresh(wrapped):
     """
     Decorator to reset the expire time for this session's key in Redis.
+    This will mark the `_session_state.please_refresh` as True, to be 
+    handled in a callback.
+    To immediately persist a session, call `session.do_refresh`.
     """
     def wrapped_refresh(session, *arg, **kw):
         result = wrapped(session, *arg, **kw)
@@ -144,10 +148,14 @@ def refresh(wrapped):
 
     return wrapped_refresh
 
+
 def persist(wrapped):
     """
     Decorator to persist in Redis all the data that needs to be persisted for
     this session and reset the expire time.
+    This will mark the `_session_state.please_persist` as True, to be 
+    handled in a callback.
+    To immediately persist a session, call `session.do_persist`.
     """
     def wrapped_persist(session, *arg, **kw):
         result = wrapped(session, *arg, **kw)


### PR DESCRIPTION
This was fun to fix.

`pyramid_redis_sessions` was communicating with Redis WAY TOO MUCH.    It set the TTL every single time an attribute was touched.  Same thing with SET.

This fixes that!

The `@persist` and `@refresh` decorators now simply mark the `_session_state` as needing to persist or refresh.

The actual work is carried out by `add_finished_callback` (which always runs).   it could be changed to `add_response_callback`.  That will require a simple find/replace AND updating the args to `_finished_callback`.

If you want to immediately persist, the session now has `do_persist` and `do_refresh` methods.  The callback function actually calls these too.

In order to make tests pass, the sessions must be told to `inst.do_persist()`.  

This patch cuts down on traffic A LOT.  like a lot a lot.  