### PR TITLE
Consolidate EXISTS+GET into GET

### DIFF
--- a/pyramid_redis_sessions/__init__.py
+++ b/pyramid_redis_sessions/__init__.py
@@ -9,6 +9,7 @@ from pyramid.session import (
 
 from .compat import cPickle
 from .connection import get_default_connection
+from .exceptions import InvalidSession
 from .session import RedisSession
 from .util import (
     _generate_session_id,
@@ -199,22 +200,31 @@ def RedisSessionFactory(
             generator=id_generator,
             )
 
-        if session_id_from_cookie and redis.exists(session_id_from_cookie):
+        try:
+            if not session_id_from_cookie:
+                raise InvalidSession('initial new session')
             session_id = session_id_from_cookie
             session_cookie_was_valid = True
-        else:
+            session = RedisSession(
+                redis=redis,
+                session_id=session_id,
+                new=not session_cookie_was_valid,
+                new_session=new_session,
+                serialize=serialize,
+                deserialize=deserialize,
+                )
+        except InvalidSession, e:
             session_id = new_session()
             session_cookie_was_valid = False
-
-        session = RedisSession(
-            redis=redis,
-            session_id=session_id,
-            new=not session_cookie_was_valid,
-            new_session=new_session,
-            serialize=serialize,
-            deserialize=deserialize,
-            )
-
+            session = RedisSession(
+                redis=redis,
+                session_id=session_id,
+                new=not session_cookie_was_valid,
+                new_session=new_session,
+                serialize=serialize,
+                deserialize=deserialize,
+                )
+    
         set_cookie = functools.partial(
             _set_cookie,
             cookie_name=cookie_name,

--- a/pyramid_redis_sessions/exceptions.py
+++ b/pyramid_redis_sessions/exceptions.py
@@ -1,0 +1,3 @@
+class InvalidSession(Exception):
+    """The session is invalid"""
+    pass

--- a/pyramid_redis_sessions/session.py
+++ b/pyramid_redis_sessions/session.py
@@ -9,6 +9,7 @@ from pyramid.interfaces import ISession
 from zope.interface import implementer
 
 from .compat import cPickle
+from .exceptions import InvalidSession
 from .util import (
     persist,
     refresh,
@@ -143,6 +144,8 @@ class RedisSession(object):
         """Get and deserialize the persisted data for this session from Redis.
         """
         persisted = self.redis.get(session_id or self.session_id)
+        if persisted is None:
+            raise InvalidSession("`session_id` (%s) not in Redis" % session_id)
         deserialized = self.deserialize(persisted)
         return deserialized
 


### PR DESCRIPTION
Removed the initial call to EXISTS.

Instead, the package will attempt to create a session in a `try` block.  If it passes, great.  If it fails, the process is repeated but new session params are used.

https://github.com/ericrasmussen/pyramid_redis_sessions/issues/64