### PR TITLE
Fix deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ env*/
 _env*/
 tmp/
 __pycache__
+.tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -157,3 +157,10 @@ Changelog
 
              * Updated to official/stable release version after successful
                alpha period and in order to support pip installs
+
+-07/10/2016: Changes for 1.1.0
+
+             * Now requires redis-py >= 2.10.0 and fixes deprecation warnings.
+               This does require that you upgrade redis-py (which in turn
+               requires python > 2.5) to install the latest
+               pyramid_redis_sessions

--- a/pyramid_redis_sessions/__init__.py
+++ b/pyramid_redis_sessions/__init__.py
@@ -73,8 +73,8 @@ def RedisSessionFactory(
     password=None,
     socket_timeout=None,
     connection_pool=None,
-    charset='utf-8',
-    errors='strict',
+    encoding='utf-8',
+    encoding_errors='strict',
     unix_socket_path=None,
     client_callable=None,
     serialize=cPickle.dumps,
@@ -162,8 +162,8 @@ def RedisSessionFactory(
 
       socket_timeout
       connection_pool
-      charset
-      errors
+      encoding
+      encoding_errors
       unix_socket_path
     """
     def factory(request, new_session_id=get_unique_session_id):
@@ -174,8 +174,8 @@ def RedisSessionFactory(
             password=password,
             socket_timeout=socket_timeout,
             connection_pool=connection_pool,
-            charset=charset,
-            errors=errors,
+            encoding=encoding,
+            encoding_errors=encoding_errors,
             unix_socket_path=unix_socket_path,
             )
 

--- a/pyramid_redis_sessions/tests/test_factory.py
+++ b/pyramid_redis_sessions/tests/test_factory.py
@@ -158,7 +158,7 @@ class TestRedisSessionFactory(unittest.TestCase):
         # settings to get the expected header to compare against
         response_to_check_against = webob.Response()
         response_to_check_against.delete_cookie(
-            key=cookie_name,
+            cookie_name,
             path=cookie_path,
             domain=cookie_domain,
             )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except IOError:
     README = CHANGES = ''
 
 # set up requires
-install_requires = ['redis>=2.4.11, != 2.9.1', 'pyramid>=1.3']
+install_requires = ['redis>=2.10.0', 'pyramid>=1.3']
 testing_requires = ['nose']
 testing_extras = testing_requires + ['coverage']
 docs_extras = ['sphinx']

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist =
+    py27,py35
+
+[testenv]
+basepython =
+    py27: python2.7
+    py35: python3.5
+
+commands =
+    pip install pyramid_redis_sessions[testing]
+    nosetests --with-coverage {posargs:}


### PR DESCRIPTION
redis-py has gone through major updates in the last couple of years and it's time to require newer versions