### PR TITLE
[work-in-progress] Correct cookie behavior

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 # manage package version
-package_version = '1.0.1'
+package_version = '1.0.1+experimental'
 
 
 # get readme and changes


### PR DESCRIPTION
This PR enhances some aspects with `pyramid_redis_session` cookie behavior.
- Before it was not possible for a view to signal that `Set-Cookie` (session cookie) should not be present in a response. This made it impossible to create performant image generating views where responses would be cached in proxes (CloudFlare, others). Now this behavior can be signaled through the presence of `expires` or `cache-control` headers. However this behavior is not perfect, but guidelining. We do not actually check if the response is actually cached (cache timestamp in the future), but only check the mere presence of a caching headers to keep the code simple. I am not sure how what would be a clean API to make this behavior more flexible for more complex header scenarios. 
- Always set `Vary: Cookie` response if we set a session cookie. This way we tell the downstream proxy that the response should not be cached, or at least when it's accidentally cached it's not served to another user.

There are no tests yet. I am asking for an advice what would be the project best practice to write tests for checking headers in response.
