### PR TITLE
allow urls to be excluded from renewing session ttl

### DIFF
--- a/pyramid_redis_sessions/tween.py
+++ b/pyramid_redis_sessions/tween.py
@@ -1,0 +1,12 @@
+def no_session_renew_factory(handler, registry):
+
+    def no_session_renew_tween(request):
+        bypass_paths = request.registry.settings.get('redis.sessions.bypass_routes', '').split(',')
+        if request.path in bypass_paths:
+            request.session._no_update = True
+
+        response = handler(request)
+
+        return response
+
+    return no_session_renew_tween

--- a/pyramid_redis_sessions/util.py
+++ b/pyramid_redis_sessions/util.py
@@ -139,7 +139,10 @@ def refresh(wrapped):
     """
     def wrapped_refresh(session, *arg, **kw):
         result = wrapped(session, *arg, **kw)
-        session.redis.expire(session.session_id, session.timeout)
+        if hasattr(session, '_no_update'):
+            del session._no_update
+        else:
+            session.redis.expire(session.session_id, session.timeout)
         return result
 
     return wrapped_refresh


### PR DESCRIPTION
As discussed in Issue #52 

provides a tween to set a flag on the session for urls defined in settings
check session for no update flag in refresh decorator

example:
redis.sessions.bypass_routes=/example/route,/second/route/to/exclude